### PR TITLE
fix normalization factor for green function

### DIFF
--- a/scripts/generate_figure_synthetics.py
+++ b/scripts/generate_figure_synthetics.py
@@ -151,7 +151,12 @@ colors = extend_if_necessary(colors, n_syn_model, "colors")
 line_widths = extend_if_necessary(line_widths, n_syn_model, "line_widths")
 
 
-path_observations = config.get("GENERAL", "path_observations")
+path_observations = config.get(
+    "GENERAL", "path_observations", fallback="./observations"
+)
+path_computed_synthetics = config.get(
+    "GENERAL", "path_computed_synthetics", fallback="./computed_synthetics"
+)
 kind_misfit = config.get("GENERAL", "Misfit", fallback="min_shifted_normalized_rms")
 
 valid_misfits = {
@@ -356,6 +361,7 @@ if "pyprop8" in software and source_files:
         generic_wave.t_after = duration
 
 if "instaseis" in software and source_files:
+    os.makedirs(path_computed_synthetics, exist_ok=True)
     list_synthetics = generate_synthetics_instaseis(
         db_name,
         source_files,
@@ -363,7 +369,7 @@ if "instaseis" in software and source_files:
         t1,
         kind_vd,
         components,
-        path_observations,
+        path_computed_synthetics,
         projection,
         instaseis_modes,
     )

--- a/scripts/instaseis_routines.py
+++ b/scripts/instaseis_routines.py
@@ -93,16 +93,26 @@ def geographic2geocentric(lat):
 
 def resample_sliprate(slip_rate, dt, dt_new, nsamp):
     """
-    For convolution, the sliprate is needed at the sampling of the fields
-    in the database. This function resamples the sliprate using linear
-    interpolation.
+    Resample sliprate using linear interpolation, preserving total slip.
 
-    :param dt: desired sampling
+    :param slip_rate: original slip-rate array
+    :param dt: original sampling interval
+    :param dt_new: new sampling interval
     :param nsamp: desired number of samples
     """
+
     t_new = np.linspace(0, nsamp * dt_new, nsamp, endpoint=False)
     t_old = np.linspace(0, dt * len(slip_rate), len(slip_rate), endpoint=False)
-    return np.interp(t_new, t_old, slip_rate)
+    slip_rate_new = np.interp(t_new, t_old, slip_rate)
+
+    # Scale to preserve total slip (integral)
+    total_slip_old = np.sum(slip_rate) * dt
+    total_slip_new = np.sum(slip_rate_new) * dt_new
+
+    if total_slip_new != 0:
+        slip_rate_new *= total_slip_old / total_slip_new
+
+    return slip_rate_new
 
 
 def transform_to_spherical(xyz, proj_string, attrs):
@@ -209,7 +219,7 @@ def generate_synthetics_instaseis_green(
     myproj,
     kind_vd,
     components,
-    path_observations,
+    path_computed_synthetics,
     station_coords,
     progress_bar,
 ):
@@ -245,7 +255,9 @@ def generate_synthetics_instaseis_green(
         ), "for using the green function mode, slip_threshold should be small enough"
 
     db_name = f"{db.info.velocity_model}_{db.info.period}s"
-    hdf5_file = f"{path_observations}/greens_{db_name}_dh{dh}_nz{NZ}.h5"
+    hdf5_file = (
+        f"{path_computed_synthetics}/greens_{db_name}_{kind_vd}_dh{dh}_nz{NZ}.h5"
+    )
     synthetics = Stream()
 
     for station_code in station_coords:
@@ -260,7 +272,6 @@ def generate_synthetics_instaseis_green(
             station=station,
         )
         # print(f"generating instaseis synthetics for station {station}")
-
         for isrc in range(nsource):
             fault_tag = fault_tags[isrc]
             segment = segment_indices[isrc]
@@ -293,16 +304,14 @@ def generate_synthetics_instaseis_green(
                         origin_time=t1,
                         dt=dt,
                     )
-                    sliprate = np.zeros_like(db.info.sliprate)
-                    sliprate[1] = 1.0 / db.info.dt
                     st0 = db.get_seismograms(
                         source=source,
                         receiver=receiver,
                         kind=kind_vd,
                         components=components,
-                        # sliprate = sliprate
                     )
                     for i in range(len(components)):
+                        st0[i].data *= 1.0 / db.info.dt
                         st0[i].stats.starttime = t1
                         st0[i].stats.source_longitude = xyz[isrc, 0]
                         st0[i].stats.source_latitude = xyz[isrc, 1]
@@ -465,7 +474,7 @@ def generate_synthetics_instaseis_green_function_mode(
     t1,
     kind_vd,
     components,
-    path_observations,
+    path_computed_synthetics,
     projection,
 ):
     db = instaseis.open_db(db_name)
@@ -486,7 +495,7 @@ def generate_synthetics_instaseis_green_function_mode(
                 projection,
                 kind_vd,
                 components,
-                path_observations,
+                path_computed_synthetics,
                 station_coords,
                 progress_bar,
             )
@@ -502,7 +511,7 @@ def generate_synthetics_instaseis_classical_mode(
     t1,
     kind_vd,
     components,
-    path_observations,
+    path_computed_synthetics,
     projection,
 ):
     db = instaseis.open_db(db_name)
@@ -544,7 +553,7 @@ def generate_synthetics_instaseis_classical_mode(
                 prefix, _ = os.path.splitext(os.path.basename(source_files[iModel]))
                 c_time = os.path.getctime(source_files[iModel])
                 fname = (
-                    f"{path_observations}/{prefix}_{c_time}_{station}_{kind_vd}_"
+                    f"{path_computed_synthetics}/{prefix}_{c_time}_{station}_{kind_vd}_"
                     f"{t1.format_iris_web_service()}.mseed"
                 )
                 if os.path.isfile(fname):
@@ -579,7 +588,7 @@ def generate_synthetics_instaseis(
     t1,
     kind_vd,
     components,
-    path_observations,
+    path_computed_synthetics,
     projection,
     modes=["classical"],
 ):
@@ -592,7 +601,7 @@ def generate_synthetics_instaseis(
             t1,
             kind_vd,
             components,
-            path_observations,
+            path_computed_synthetics,
             projection,
         )
         lst += lst1
@@ -605,7 +614,7 @@ def generate_synthetics_instaseis(
             t1,
             kind_vd,
             components,
-            path_observations,
+            path_computed_synthetics,
             projection,
         )
         lst += lst2


### PR DESCRIPTION
There was a normalization factor error missing for instaseis green function mode:
```st0[i].data *= 1.0 / db.info.dt```

before:
<img width="1646" height="898" alt="7000pn9s_main_displacement_instaseis_generic_a2s_main" src="https://github.com/user-attachments/assets/975e729e-411b-4a2b-b0bc-2d343fdb0cde" />
after:
<img width="1646" height="898" alt="7000pn9s_main_displacement_instaseis_generic_a2s_fixed" src="https://github.com/user-attachments/assets/abc2337b-9bf1-486c-9611-49d3a94b52ef" />
using PREM a10s instead of PREM a2s with the fixed code:
<img width="1646" height="898" alt="7000pn9s_main_displacement_instaseis_generic_prem_a10_fixed" src="https://github.com/user-attachments/assets/ae34fc74-21a5-4246-a4eb-585c5c5f26eb" />


This PR also:
- moves the precomputed synthetics from insteaseis in a separate folder (not anymore in observations).
- preserves total slip when reinterpolating slip-rate (tiny correction, and might be done anyway by instaseis)
- adds kind_vd in the green_function name.
