### PR TITLE
fix seissol id_station

### DIFF
--- a/src/seismic_waveform_factory/simulation/seissol.py
+++ b/src/seismic_waveform_factory/simulation/seissol.py
@@ -188,7 +188,9 @@ def compile_inv_lut_gm(folder_prefix, projection, station_coords):
     receiver_files = glob.glob(file_pattern)
 
     for fn in receiver_files:
-        id_station = int(fn.split(f"{folder_prefix}-receiver-")[1].split("-")[0])
+        id_station = int(
+            fn.split(f"{folder_prefix}-receiver-")[1].split("-")[0].split(".dat")[0]
+        )
 
         # Load SeisSol receiver coordinates
         xyzs = read_seissol_receiver_file(folder_prefix, id_station, coords_only=True)


### PR DESCRIPTION
fix this issue:
```python
output_3d/dyn_0007_coh0.25_1.0_B0.9_C0.2_R0.6_3d-receiver-00003.dat
Traceback (most recent call last):
  File "/project/project_465002391/ulrich/seissol_base/local/bin/swf", line 7, in <module>
    sys.exit(main())
             ^^^^^^
  File "/project/project_465002391/ulrich/seissol_base/local/lib/python3.11/site-packages/seismic_waveform_factory/cli.py", line 65, in main
    args.func(args)
  File "/project/project_465002391/ulrich/seissol_base/local/lib/python3.11/site-packages/seismic_waveform_factory/figure/generate_figure_synthetics_subparser.py", line 16, in run
    main(args)
  File "/project/project_465002391/ulrich/seissol_base/local/lib/python3.11/site-packages/seismic_waveform_factory/figure/generate_figure_synthetics.py", line 298, in main
    st, duration = generate_synthetics(
                   ^^^^^^^^^^^^^^^^^^^^
  File "/project/project_465002391/ulrich/seissol_base/local/lib/python3.11/site-packages/seismic_waveform_factory/figure/generate_figure_synthetics.py", line 235, in generate_synthetics
    list_synthetics = collect_seissol_synthetics(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/project/project_465002391/ulrich/seissol_base/local/lib/python3.11/site-packages/seismic_waveform_factory/simulation/seissol.py", line 231, in collect_seissol_synthetics
    compile_inv_lut_gm(seissol_output_path, projection, station_coords)
  File "/project/project_465002391/ulrich/seissol_base/local/lib/python3.11/site-packages/seismic_waveform_factory/simulation/seissol.py", line 192, in compile_inv_lut_gm
    id_station = int(fn.split(f"{folder_prefix}-receiver-")[1].split("-")[0])
```